### PR TITLE
fix: missing module tyme4py.unit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'tyme4py.sixtycycle',
         'tyme4py.solar',
         'tyme4py.rabbyung',
+        'tyme4py.unit',
         'tyme4py.util'
     ],
     url='https://github.com/6tail/tyme4py',


### PR DESCRIPTION
This is to fix below error:

```
Python 3.14.2 (main, Dec 17 2025, 20:54:49) [Clang 21.1.4 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from tyme4py import unit
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    from tyme4py import unit
ImportError: cannot import name 'unit' from 'tyme4py'
```

After the patch:
```
Python 3.14.2 (main, Dec 17 2025, 20:54:49) [Clang 21.1.4 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from tyme4py import unit
>>>
```